### PR TITLE
Fixed compile issue as dependencies have updated.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,7 @@ use syntax::symbol::Symbol;
 use block::{Block, Describe, It, Bench};
 
 pub fn parse(parser: &mut Parser) -> Describe {
-    parse_describe(Symbol::intern("_"), parser)
+    parse_describe(Symbol::intern("__"), parser)
 }
 
 fn parse_describe(name: Symbol, parser: &mut Parser) -> Describe {
@@ -19,7 +19,7 @@ fn parse_describe(name: Symbol, parser: &mut Parser) -> Describe {
         }
 
         let span = parser.span;
-        if let token::Ident(ident) = parser.token {
+        if let token::Ident(ident, _ident_style) = parser.token {
             match &*ident.name.as_str() {
                 "describe" | "context" => {
                     parser.bump();


### PR DESCRIPTION
Fixed compile issue as dependencies (syntax) have updated and are not quite backwardly compatible.
Also https://github.com/rust-lang/rfcs/blob/master/text/2166-impl-only-use.md
means that using '_' is behind a feature flag, so have switched to __ as
a workaround. - (The latter may only be an issue for people on the nightly compiler).