### PR TITLE
Fix 'feature use_extern_macros has been stable...'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ speculate = "0.1.0"
 And add the following to the top of the Rust file you want to add tests for:
 
 ```rust
-#![feature(use_extern_macros)]  // Allows loading new procedural macros.
-
 #[cfg(test)]
 extern crate speculate;
 


### PR DESCRIPTION
Update README.md to remove the following line from the example code:

```rust
#![feature(use_extern_macros)]  // Allows loading new procedural macros.
```

On the Rust nightly for 2018-11-22, this line triggers the following build failure:

```
warning: the feature `use_extern_macros` has been stable since 1.30.0 and no longer requires an attribute to enable
 --> tests/first_spec.rs:1:12
  |
1 | #![feature(use_extern_macros)]  // Allows loading new procedural macros.
  |            ^^^^^^^^^^^^^^^^^
  |
  = note: #[warn(stable_features)] on by default

error: build failed
```