### PR TITLE
Make Speculate compile on stable as well as nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: rust
-rust: nightly
+rust:
+  - stable
+  - beta
+  - nightly
 script:
   - cargo build --verbose
   - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     script:
       - cargo build --verbose
       - cargo test --verbose
-  - rust: nightly:
+  - rust: nightly
     script:
       - cargo build --verbose
       - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
 language: rust
-rust:
-  - stable
-  - beta
-  - nightly
-script:
-  - cargo build --verbose
-  - cargo test --verbose
-  - cargo bench --verbose
+
+# Benches only work on nightly. See https://github.com/rust-lang/rust/issues/29553
+matrix:
+  include:
+  - rust: stable
+    script:
+      - cargo build --verbose
+      - cargo test --verbose
+  - rust: beta
+    script:
+      - cargo build --verbose
+      - cargo test --verbose
+  - rust: nightly:
+    script:
+      - cargo build --verbose
+      - cargo test --verbose
+      - cargo bench --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ syn = { version = "^0.14", features = [ "full" ] }
 proc-macro2 = { version = "^0.4", features = [ "nightly" ] }
 
 quote = "^0.6"
+unicode-xid = "^0.1"
 
 [lib]
 proc-macro = true
+
+[features]
+default = []
+nightly = []

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,6 +1,6 @@
 use syn;
 use syn::synom::Synom;
-
+use unicode_xid::UnicodeXID;
 use proc_macro2::Span;
 
 pub struct Root(pub(crate) Describe);
@@ -161,10 +161,10 @@ fn litstr_to_ident(l: &syn::LitStr) -> syn::Ident {
 
     let first_ch = chars.next().unwrap();
 
-    if !first_ch.is_xid_start() {
+    if !UnicodeXID::is_xid_start(first_ch) {
         id.push('_');
 
-        if first_ch.is_xid_continue() {
+        if UnicodeXID::is_xid_continue(first_ch) {
             id.push(first_ch);
         } else {
             added_underscore = true;
@@ -174,7 +174,7 @@ fn litstr_to_ident(l: &syn::LitStr) -> syn::Ident {
     }
 
     for ch in chars {
-        if ch.is_xid_continue() {
+        if UnicodeXID::is_xid_continue(ch) {
             id.push(ch);
             added_underscore = false;
         } else if !added_underscore {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,6 +1,12 @@
-extern crate speculate;
+#[cfg(not(feature="nightly"))]
+#[macro_use]
+extern crate speculate as other_speculate;
 
-use speculate::speculate;
+#[cfg(feature="nightly")]
+extern crate speculate as other_speculate;
+
+#[cfg(feature="nightly")]
+use other_speculate::speculate;
 
 pub fn zero() -> u32 {
     0
@@ -75,13 +81,15 @@ speculate! {
 
 // Parsing edge cases
 mod ec1 {
-    use speculate::speculate;
+    #[cfg(feature="nightly")]
+    use other_speculate::speculate;
 
     speculate!{}
 }
 
 mod ec2 {
-    use speculate::speculate;
+    #[cfg(feature="nightly")]
+    use other_speculate::speculate;
     
     speculate! {
         before {}
@@ -95,7 +103,8 @@ mod ec2 {
 }
 
 mod ec3 {
-    use speculate::speculate;
+    #[cfg(feature="nightly")]
+    use other_speculate::speculate;
     
     speculate! {
         it "foo" {}
@@ -103,7 +112,8 @@ mod ec3 {
 }
 
 mod ec4 {
-    use speculate::speculate;
+    #[cfg(feature="nightly")]
+    use other_speculate::speculate;
     
     speculate! {
         after {}
@@ -111,7 +121,8 @@ mod ec4 {
 }
 
 mod ec5 {
-    use speculate::speculate;
+    #[cfg(feature="nightly")]
+    use other_speculate::speculate;
     
     speculate! {
         before {}
@@ -121,7 +132,8 @@ mod ec5 {
 }
 
 mod attributes {
-    use speculate::speculate;
+    #[cfg(feature="nightly")]
+    use other_speculate::speculate;
     
     speculate! {
         #[ignore]

--- a/tests/example.rs
+++ b/tests/example.rs
@@ -1,6 +1,12 @@
-extern crate speculate;
+#[cfg(not(feature="nightly"))]
+#[macro_use]
+extern crate speculate as other_speculate;
 
-use speculate::speculate;
+#[cfg(feature="nightly")]
+extern crate speculate as other_speculate;
+
+#[cfg(feature="nightly")]
+use other_speculate::speculate;
 
 speculate! {
     const ZERO: i32 = 0;


### PR DESCRIPTION
This fixes #18, and adds a "nightly" feature that re-adds the features only currently available on nightly.