### PR TITLE
Switch to Rust Edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Utkarsh Kukreti <utkarshkukreti@gmail.com>", "Grégoire Geis <git@gr
 description = "An RSpec inspired minimal testing framework for Rust."
 repository = "https://github.com/utkarshkukreti/speculate.rs"
 license = "MIT"
+edition = "2018"
 
 [dependencies]
 # Full features are needed for Syn, in order to have the Item enum.

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -1,5 +1,4 @@
 #![feature(proc_macro_hygiene, test)]
-extern crate speculate;
 extern crate test;
 
 use speculate::speculate;

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,6 +1,5 @@
 use proc_macro2::Span;
-use syn;
-use syn::synom::Synom;
+use syn::{alt, braces, call, custom_keyword, do_parse, many0, named, punct, syn, synom::Synom};
 use unicode_xid::UnicodeXID;
 
 pub struct Root(pub(crate) Describe);

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,8 +1,6 @@
+use crate::block::{Bench, Block, Describe, It};
 use proc_macro2::{Ident, TokenStream};
-
-use block::{Bench, Block, Describe, It};
-use quote::ToTokens;
-use syn;
+use quote::{quote_spanned, ToTokens};
 
 pub trait Generate {
     fn generate(self, up: Option<&Describe>) -> TokenStream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 fn get_root_name() -> proc_macro2::Ident {
     let start_line = proc_macro::Span::call_site().start().line;
     let module_name = format!("speculate_{}", start_line);
-    return syn::Ident::new(&module_name, proc_macro2::Span::call_site());
+
+    syn::Ident::new(&module_name, proc_macro2::Span::call_site())
 }
 
 // TODO: Get rid of this once proc_macro_span stabilises
@@ -31,7 +32,8 @@ static GLOBAL_SPECULATE_COUNT: AtomicUsize = AtomicUsize::new(0);
 fn get_root_name() -> proc_macro2::Ident {
     let count = GLOBAL_SPECULATE_COUNT.fetch_add(1, Ordering::SeqCst);
     let module_name = format!("speculate_{}", count);
-    return syn::Ident::new(&module_name, proc_macro2::Span::call_site());
+
+    syn::Ident::new(&module_name, proc_macro2::Span::call_site())
 }
 
 /// Creates a `test` module using a friendly syntax.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,27 +4,17 @@
 //! Please see the documentation for the [`speculate`](./macro.speculate.html) macro
 //! for more information and examples.
 
-#![cfg_attr(feature = "nightly", feature(proc_macro_span))]
-
 extern crate proc_macro;
-extern crate proc_macro2;
-extern crate unicode_xid;
 
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate quote;
+use crate::{block::Root, generator::Generate};
+use proc_macro::TokenStream;
+use quote::quote;
 
 mod block;
 mod generator;
 
-use block::Root;
-use generator::Generate;
-
-use proc_macro::TokenStream;
-
 #[cfg(not(feature = "nightly"))]
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[cfg(feature = "nightly")]
 fn get_root_name() -> proc_macro2::Ident {
@@ -35,7 +25,7 @@ fn get_root_name() -> proc_macro2::Ident {
 
 // TODO: Get rid of this once proc_macro_span stabilises
 #[cfg(not(feature = "nightly"))]
-static GLOBAL_SPECULATE_COUNT: AtomicUsize = ATOMIC_USIZE_INIT;
+static GLOBAL_SPECULATE_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 #[cfg(not(feature = "nightly"))]
 fn get_root_name() -> proc_macro2::Ident {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,11 +1,4 @@
-#[cfg(not(feature = "nightly"))]
-#[macro_use]
 extern crate speculate as other_speculate;
-
-#[cfg(feature = "nightly")]
-extern crate speculate as other_speculate;
-
-#[cfg(feature = "nightly")]
 use other_speculate::speculate;
 
 pub fn zero() -> u32 {
@@ -81,14 +74,12 @@ speculate! {
 
 // Parsing edge cases
 mod ec1 {
-    #[cfg(feature = "nightly")]
     use other_speculate::speculate;
 
     speculate! {}
 }
 
 mod ec2 {
-    #[cfg(feature = "nightly")]
     use other_speculate::speculate;
 
     speculate! {
@@ -103,7 +94,6 @@ mod ec2 {
 }
 
 mod ec3 {
-    #[cfg(feature = "nightly")]
     use other_speculate::speculate;
 
     speculate! {
@@ -112,7 +102,6 @@ mod ec3 {
 }
 
 mod ec4 {
-    #[cfg(feature = "nightly")]
     use other_speculate::speculate;
 
     speculate! {
@@ -121,7 +110,6 @@ mod ec4 {
 }
 
 mod ec5 {
-    #[cfg(feature = "nightly")]
     use other_speculate::speculate;
 
     speculate! {
@@ -132,7 +120,6 @@ mod ec5 {
 }
 
 mod attributes {
-    #[cfg(feature = "nightly")]
     use other_speculate::speculate;
 
     speculate! {

--- a/tests/example.rs
+++ b/tests/example.rs
@@ -1,12 +1,5 @@
-#[cfg(not(feature = "nightly"))]
-#[macro_use]
-extern crate speculate as other_speculate;
-
-#[cfg(feature = "nightly")]
-extern crate speculate as other_speculate;
-
-#[cfg(feature = "nightly")]
-use other_speculate::speculate;
+extern crate speculate;
+use speculate::speculate;
 
 speculate! {
     const ZERO: i32 = 0;


### PR DESCRIPTION
I made some changes to make the project compatible with the newest edition of Rust (2018). It mainly reduced amount of `extern crate` and modified `use` declarations.