### PR TITLE
PoC for tests returning result

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ syn = { version = "^0.14", features = [ "full" ] }
 # Nightly feature is required to preserve span information.
 proc-macro2 = { version = "^0.4", features = [ "nightly" ] }
 
+failure = "0.1.5"
 quote = "^0.6"
 unicode-xid = "^0.1"
 

--- a/tests/example.rs
+++ b/tests/example.rs
@@ -29,4 +29,18 @@ speculate! {
             assert_eq!(ONE, sub(two, ONE));
         }
     }
+
+    describe "error handling" {
+      fn maybe_badness() -> Result<(), Error> {
+          Ok(())
+      }
+
+      before {
+          maybe_badness()?;
+      }
+
+      it "could return errors" {
+          maybe_badness()?;
+      }
+    }
 }


### PR DESCRIPTION
This PR is intended to start a discussion and does not claim to be complete. It changes all specs to return `Result` which means that both `before/after` and `it` blocks can make use of the question mark postfix to rid itself of setup failures. For example,
```
before {
    File::create("foo.txt").unwrap().write_all(b"Test me!").unwrap();
}
```
becomes
```
before {
    File::create("foo.txt")?.write_all(b"Test me!")?;
}
```
The main implementation note is that we need to special-case `#[should_panic]` as such a test is only allowed to return `()`. I'm not sure if there are other such special cases?

I'm new to Rust, so I don't know:
- will this be a breaking change in some case?
- is the dependency on `failure` acceptable?
- does the implicit dependency on `std::result::Result` an issue for no_std? Does speculate have an ambition to be useful in no_std context?