### PR TITLE
Enable using ? in tests

### DIFF
--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -133,6 +133,11 @@ mod errors {
             maybe_fail_u8()?;
         }
 
+        #[should_panic]
+        it "rust does not allow Ok(()) with should_panic" {
+            panic!("Completely normal");
+        }
+
         describe "actually fails" {
             errtype(String)
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -119,6 +119,64 @@ mod ec5 {
     }
 }
 
+mod errors {
+    use other_speculate::speculate;
+
+    fn maybe_fail_u8() -> Result<(), u8> { Ok(()) }
+    fn maybe_fail_string() -> Result<(), String> { Ok(()) }
+    fn will_fail() -> Result<(), String> { Err("badness".to_owned()) }
+
+    speculate! {
+        errtype(u8)
+
+        it "error would be a u8" {
+            maybe_fail_u8()?;
+        }
+
+        describe "actually fails" {
+            errtype(String)
+
+            #[ignore]
+            it "fails with a string" {
+                will_fail()?;
+            }
+
+            it "good badness" {
+                assert_eq!("badness", test_fails_with_a_string().unwrap_err());
+            }
+        }
+    }
+
+    speculate! {
+        errtype(u8)
+
+        describe "it even propagates" {
+            it "bar" {
+                maybe_fail_u8()?;
+            }
+        }
+
+        describe "and can be overridden" {
+            errtype(String)
+
+            it "foo" {
+                maybe_fail_string()?;
+            }
+        }
+    }
+
+    speculate! {
+        describe "my before blocks can use ? too" {
+            errtype(u8)
+
+            before {
+                maybe_fail_u8()?;
+            }
+            it "foo" {}
+        }
+    }
+}
+
 mod attributes {
     use other_speculate::speculate;
 


### PR DESCRIPTION
When writing tests for code that does I/O or which requires setup that can theoretically fail, you may end up with a lot of expect/unwrap boiler plate. Unit tests can return `Result<(), E>` which enables using the `?` operator to return early on error cases, but there is no way to achieve this in speculate.rs. 

This PR allows describe blocks to specify that their tests can return `Result<(), E>` by including an `errtype(E)` entry which will make all the tests in that `describe` block and any nested `describe` blocks return `Result<(), E>`. This includes any `before` or `after` blocks. For example:
```
speculate! {
  errtype(Error)

  before {
    fs::write("/the/file", "")?;
  }

  it "reads the file" {
    let data = read_the_file()?;
    assert!(data.len() > 0);
  }
}
```
This will desugar into a test which returns `Result<(), Error>` and gets an `Ok(())` appended at the end, e.g.
```
#[test]
fn test_reads_the_file() -> Result<(), Error> {
  fs::write("/the/file", "")?;
  let data = read_the_file()?;
  assert!(data.len() > 0);
  Ok(())
}
```
I think using a predicate like this makes sense because it should not cause trouble, even if some or all of the covered tests happen not to contain `?`. Thus, this PR contains no way to annotate a specific test or for a nested block to opt out.

There is one special case, namely that Rust requires `#[should_panic]` tests to return `()`. Given that such tests are typically sprinkled among other tests, it would be annoying to have to isolate them in their own `describe`. Instead, this PR detects such tests and avoids turning them into `-> Result<(), E>`.

Replaces #24.