### PR TITLE
Add keyword and readme information to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ repository = "https://github.com/utkarshkukreti/speculate.rs"
 readme = "README.md"
 license = "MIT"
 edition = "2018"
+categories = ["development-tools::testing"]
+keywords = ["rspec", "test", "testing", ]
 
 [dependencies]
 # Full features are needed for Syn, in order to have the Item enum.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.1"
 authors = ["Utkarsh Kukreti <utkarshkukreti@gmail.com>", "Grégoire Geis <git@gregoirege.is>"]
 description = "An RSpec inspired minimal testing framework for Rust."
 repository = "https://github.com/utkarshkukreti/speculate.rs"
+readme = "README.md"
 license = "MIT"
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# speculate.rs [![Build Status](https://travis-ci.org/utkarshkukreti/speculate.rs.svg?branch=master)](https://travis-ci.org/utkarshkukreti/speculate.rs)
+# speculate.rs [![Build Status](https://travis-ci.org/utkarshkukreti/speculate.rs.svg?branch=master)](https://travis-ci.org/utkarshkukreti/speculate.rs) [![crate-name at crates.io](https://img.shields.io/crates/v/speculate.svg)](https://crates.io/crates/speculate)
 
 > An RSpec inspired minimal testing framework for Rust.
 


### PR DESCRIPTION
There is no crates.io screen of speculate at the moment, so add README

## I did
- Add crates.io badge to README
- readme,keyword,categories info add Cargo.toml

<img width="518" alt="スクリーンショット 2019-04-22 10 51 18" src="https://user-images.githubusercontent.com/23740172/56478767-96687b80-64ec-11e9-87c3-042c8a4a2eaa.png">
