### PR TITLE
Release 0.1.3. Update dependencies to recent packages.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "speculate"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Utkarsh Kukreti <utkarshkukreti@gmail.com>", "Grégoire Geis <git@gregoirege.is>"]
 description = "An RSpec inspired minimal testing framework for Rust."
 repository = "https://github.com/utkarshkukreti/speculate.rs"
@@ -11,14 +11,10 @@ categories = ["development-tools::testing"]
 keywords = ["rspec", "test", "testing", ]
 
 [dependencies]
-# Full features are needed for Syn, in order to have the Item enum.
-syn = { version = "^0.14", features = [ "full" ] }
-
-# Nightly feature is required to preserve span information.
-proc-macro2 = { version = "^0.4", features = [ "nightly" ] }
-
-quote = "^0.6"
-unicode-xid = "^0.1"
+syn = { version = "1.0", features = ["full"] }
+proc-macro2 = "^1.0"
+quote = "^1.0"
+unicode-ident = "^1.0"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Hi ! 

I was working on the bootstrapping of rust packages on guix, and have found that this package makes the bootstrapping more difficult because of its old dependencies. I've updated the dependencies and made everything stick together so that test files would pass without being modified. 

The structs in block.rs are strictly the same, expect for After and Before which became both vectors of statements instead of vectors of blocks. The logic stays the same with some light adaptations. In particular, there is no Root anymore, the speculate top-level is simply considered as a describe block. 

Normally tests should pass properly, I'm also going to test this on dependent packages, if I don't come back with more info in the coming month, then it works.